### PR TITLE
fixed bugs in displaying Recent PubMed Articles

### DIFF
--- a/public/js/p3/widget/ExternalItemFormatter.js
+++ b/public/js/p3/widget/ExternalItemFormatter.js
@@ -7,7 +7,7 @@ define([
 ){
 
 	var formatters = {
-		"default": function(item, options){
+		"default": function(item, options, shownode){
 			console.log("item: ", item);
 			options = options || {};
 
@@ -23,7 +23,7 @@ define([
 			return table;
 		},
 
-		"pubmed_data": function(item, options){
+		"pubmed_data": function(item, options, shownode){
 			options = options || {};
 			var taxonName = item.taxon_name;
 			var eutilSeaarchURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=" + taxonName + "&retmode=json";
@@ -41,62 +41,71 @@ define([
 				handleAs: "json"
 			}).then(lang.hitch(this, function(pubmedList){
 				console.log("pubmedList=", pubmedList);
-				var pmids= pubmedList.esearchresult.idlist;
-				var retmax=5;
-				var eutilSummaryURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmax=" + retmax+"&retmode=json";
-				if (options.hideExtra == false)
+				if (pubmedList.esearchresult.count>0)
 				{
-					eutilSummaryURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmode=json";				
-				}
-				xhr.get(eutilSummaryURL, {
-					headers: {
-						accept: "application/json",
-						'X-Requested-With': null
-					},
-					handleAs: "json"
-				}).then(lang.hitch(this, function(pubmedSummary){
-					console.log("pubmedSummary=", pubmedSummary);
-					for(var i=0; i< pubmedSummary.result.uids.length; i++)
+					var pmids= pubmedList.esearchresult.idlist;
+					var retmax=5;
+					var eutilSummaryURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmax=" + retmax+"&retmode=json";
+					if (options.hideExtra == false)
 					{
-						var value = pubmedSummary.result.uids[i];
-						console.log("pubmedSummary value=", value);
-						var tr = domConstruct.create("tr", {},tbody);
-						var td = domConstruct.create("td",{innerHTML: pubmedSummary.result[value].pubdate}, tr);
-						tr = domConstruct.create("tr",{},tbody);
-						td = domConstruct.create("td",{innerHTML: "<a href='http://www.ncbi.nlm.nih.gov/pubmed/" + value + "' target ='_blank'>" + pubmedSummary.result[value].title + "</a>"}, tr);
-						tr = domConstruct.create("tr",{},tbody);
-						var author = pubmedSummary.result[value].lastauthor + " et al.";
-					
-						if (pubmedSummary.result[value].authors.length==1)
-						{
-							author = pubmedSummary.result[value].lastauthor;
-						}
-						else if (pubmedSummary.result[value].authors.length==2)
-						{
-							author = pubmedSummary.result[value].authors[0].name + " and " + pubmedSummary.result[value].authors[1].name;						
-						}
-
-						td = domConstruct.create("td",{innerHTML: author}, tr);
-						tr = domConstruct.create("tr",{},tbody);
-						td = domConstruct.create("td",{innerHTML: pubmedSummary.result[value].source}, tr);
-						tr = domConstruct.create("tr",{},tbody);
-						td = domConstruct.create("td", {innerHTML: "<hr>"}, tr);						
-
+						eutilSummaryURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmode=json";				
 					}
-				}));
+					xhr.get(eutilSummaryURL, {
+						headers: {
+							accept: "application/json",
+							'X-Requested-With': null
+						},
+						handleAs: "json"
+					}).then(lang.hitch(this, function(pubmedSummary){
+						console.log("pubmedSummary=", pubmedSummary);
+						for(var i=0; i< pubmedSummary.result.uids.length; i++)
+						{
+							var value = pubmedSummary.result.uids[i];
+							// console.log("pubmedSummary value=", value);
+							var tr = domConstruct.create("tr", {},tbody);
+							var td = domConstruct.create("td",{innerHTML: pubmedSummary.result[value].pubdate}, tr);
+							tr = domConstruct.create("tr",{},tbody);
+							td = domConstruct.create("td",{innerHTML: "<a href='http://www.ncbi.nlm.nih.gov/pubmed/" + value + "' target ='_blank'>" + pubmedSummary.result[value].title + "</a>"}, tr);
+							tr = domConstruct.create("tr",{},tbody);
+							var author = pubmedSummary.result[value].lastauthor + " et al.";
+					
+							if (pubmedSummary.result[value].authors.length==1)
+							{
+								author = pubmedSummary.result[value].lastauthor;
+							}
+							else if (pubmedSummary.result[value].authors.length==2)
+							{
+								author = pubmedSummary.result[value].authors[0].name + " and " + pubmedSummary.result[value].authors[1].name;						
+							}
+
+							td = domConstruct.create("td",{innerHTML: author}, tr);
+							tr = domConstruct.create("tr",{},tbody);
+							td = domConstruct.create("td",{innerHTML: pubmedSummary.result[value].source}, tr);
+							tr = domConstruct.create("tr",{},tbody);
+							td = domConstruct.create("td", {innerHTML: "<hr>"}, tr);						
+
+						}
+					}));
+				}
+				else
+				{				
+					var tr = domConstruct.create("tr", {},tbody);
+					var td = domConstruct.create("td",{innerHTML: "No recent articles found."}, tr);
+					shownode.style.display='none';
+				}
 			}));		
 			return div;
 		}
 	}
 
 	
-	return function(item, type, options) {
+	return function(item, type, options, shownode) {
 		console.log("Format Data: ", type, item);
 		var out;
 		if (type && formatters[type]) {
-			out = formatters[type](item,options)
+			out = formatters[type](item,options,shownode)
 		}else{
-			out = formatters["default"](item,options);
+			out = formatters["default"](item,options,shownode);
 		}
 
 		console.log("output: ", out);

--- a/public/js/p3/widget/ExternalItemFormatter.js
+++ b/public/js/p3/widget/ExternalItemFormatter.js
@@ -26,7 +26,7 @@ define([
 		"pubmed_data": function(item, options, shownode){
 			options = options || {};
 			var taxonName = item.taxon_name;
-			var eutilSeaarchURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=" + taxonName + "&retmode=json";
+			var eutilSeaarchURL = window.location.protocol + "//" + "eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi?db=pubmed&term=" + taxonName + "&retmode=json";
 			console.log("taxon_name = " + taxonName);
 			var div = domConstruct.create("div");			
 			console.log("Create Display Pubmed");
@@ -45,10 +45,10 @@ define([
 				{
 					var pmids= pubmedList.esearchresult.idlist;
 					var retmax=5;
-					var eutilSummaryURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmax=" + retmax+"&retmode=json";
+					var eutilSummaryURL =  window.location.protocol + "//" + "eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmax=" + retmax+"&retmode=json";
 					if (options.hideExtra == false)
 					{
-						eutilSummaryURL = "http://eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmode=json";				
+						eutilSummaryURL =  window.location.protocol + "//" + "eutils.ncbi.nlm.nih.gov/entrez/eutils/esummary.fcgi?db=pubmed&id=" + pmids + "&retmode=json";				
 					}
 					xhr.get(eutilSummaryURL, {
 						headers: {

--- a/public/js/p3/widget/TaxonomyOverview.js
+++ b/public/js/p3/widget/TaxonomyOverview.js
@@ -10,6 +10,8 @@ define([
 			ChartTooltip, domConstruct,PathJoin,GenomeFeatureSummary,DataItemFormatter,
 			SpecialtyGeneSummary,ExternalItemFormatter) {
 
+	var searchName = null;
+		
 	return declare([WidgetBase,Templated,_WidgetsInTemplateMixin], {
 		baseClass: "TaxonomyOverview",
 		disabled: false,
@@ -27,6 +29,8 @@ define([
 				this.set("taxonomy", state.taxonomy);
 			}
 
+			searchName = this.genome.taxon_name;
+			console.log("pubmed search term = ", searchName);
 		
 			var sumWidgets = ["gfSummaryWidget", "pfSummaryWidget", "spgSummaryWidget"];
 
@@ -45,14 +49,18 @@ define([
 		"createSummary": function(genome) {
 			domConstruct.empty(this.taxonomySummaryNode);
 			domConstruct.place(DataItemFormatter(genome, "taxonomy_data",{hideExtra:true}), this.taxonomySummaryNode,"first");
-			domConstruct.empty(this.pubmedSummaryNode);
-			domConstruct.place(ExternalItemFormatter(genome, "pubmed_data",{hideExtra:true}), this.pubmedSummaryNode,"first");
+			if (searchName != genome.taxon_name)
+			{
+				domConstruct.empty(this.pubmedSummaryNode);
+				domConstruct.place(ExternalItemFormatter(genome, "pubmed_data", {hideExtra:true}, this.pubmedSummaryNode2), this.pubmedSummaryNode,"first");
+				this.pubmedSummaryNode2.style.display='block';
+			}
 		},
 
 		onShowMore: function(){
 			domConstruct.empty(this.pubmedSummaryNode);
-			domConstruct.empty(this.pubmedSummaryNode2);
-			domConstruct.place(ExternalItemFormatter(this.genome, "pubmed_data",{hideExtra:false}), this.pubmedSummaryNode2,"first");
+		    domConstruct.place(ExternalItemFormatter(this.genome, "pubmed_data", {hideExtra:false}, this.pubmedSummaryNode2), this.pubmedSummaryNode,"first");
+			this.pubmedSummaryNode2.style.display='none';
 		},
 
 		startup: function(){

--- a/public/js/p3/widget/templates/TaxonomyOverview.html
+++ b/public/js/p3/widget/templates/TaxonomyOverview.html
@@ -32,7 +32,7 @@
                         <div data-dojo-attach-point="pubmedSummaryNode" style="margin:4px;padding:8px;margin-radius:4px;">
                           This feature will be returning soon.
                         </div>
-                        <div data-dojo-attach-point="pubmedSummaryNode2" style="margin:4px;padding:8px;margin-radius:4px;">
+                        <div data-dojo-attach-point="pubmedSummaryNode2" style="margin:4px;padding:8px;margin-radius:4px;display:block">
 	     					<div>Show more <i data-dojo-attach-event="click:onShowMore" class="fa icon-plus-circle fa-lg"></i></div></br>
                         </div>
                </div>


### PR DESCRIPTION
1) Hide "Show more" button when there is no pubmed record retrieved
2) Pubmed call is only needed when there is a change in Taxon name. Disallow pubmed api call when changing between tabs on the Taxonomy page
